### PR TITLE
Fix ambiguous BuildingSystem patch & improve logging on patch error

### DIFF
--- a/Lavender/FurnitureLib/FurniturePatches.cs
+++ b/Lavender/FurnitureLib/FurniturePatches.cs
@@ -95,9 +95,11 @@ namespace Lavender.FurnitureLib
             return false;
         }
 
-        [HarmonyPatch(typeof(BuildingSystem), nameof(BuildingSystem.AddFurniture))]
+        [HarmonyPatch(typeof(BuildingSystem), nameof(BuildingSystem.AddFurniture),
+            [typeof(Furniture), typeof(UnityEngine.GameObject), typeof(UnityEngine.GameObject), typeof(int), typeof(BuildingSystem.FurnitureInfo.Meta)],
+            [ArgumentType.Normal, ArgumentType.Normal, ArgumentType.Ref, ArgumentType.Normal, ArgumentType.Normal])]
         [HarmonyPrefix]
-        static bool BuildingSystem_AddFurniture_Prefix(BuildingSystem __instance, ref bool __result, Furniture furniture, GameObject gameObject, out GameObject savedGameObject, int amount = 1)
+        static bool BuildingSystem_AddFurniture_Prefix(BuildingSystem __instance, ref bool __result, Furniture furniture, GameObject gameObject, out GameObject savedGameObject, int amount)
         {
             BuildingSystem.FurnitureInfo furnitureInfo = __instance.availableFurnitures.Find((BuildingSystem.FurnitureInfo f) => f.furniture.title == furniture.title && f.gameObject == null);
             if (gameObject != null)

--- a/Lavender/Lavender.cs
+++ b/Lavender/Lavender.cs
@@ -38,10 +38,18 @@ namespace Lavender
 
             harmony = new Harmony(LCMPluginInfo.PLUGIN_GUID);
 
-            harmony.PatchAll(typeof(FurniturePatches));
-            harmony.PatchAll(typeof(ItemPatches));
-            harmony.PatchAll(typeof(RecipePatches));
-            harmony.PatchAll(typeof(CommandManagerPatches));
+            try
+            {
+                harmony.PatchAll(typeof(FurniturePatches));
+                harmony.PatchAll(typeof(ItemPatches));
+                harmony.PatchAll(typeof(RecipePatches));
+                harmony.PatchAll(typeof(CommandManagerPatches));
+            }
+            catch (Exception e)
+            {
+                LavenderLog.Error("Exception while applying Lavender patches:");
+                LavenderLog.Error(e.ToString());
+            }
         }
 
         #region FurnitureLib

--- a/Lavender/LavenderLog.cs
+++ b/Lavender/LavenderLog.cs
@@ -7,20 +7,41 @@ namespace Lavender
     {
         public static void Log(string message)
         {
-            Debug.Log($"[<color=#9585f1>Lavender</color>] {message}");
+            if (BepinexPlugin.Settings.UseBepinexLog.Value)
+            {
+                BepinexPlugin.Log.LogInfo($"[<color=#9585f1>Lavender</color>] {message}");
+            }
+            else
+            {
+                Debug.Log($"[<color=#9585f1>Lavender</color>] {message}");
+            }
         }
 
         public static void Detailed(string message)
         {
             if(BepinexPlugin.Settings.DetailedLog.Value)
             {
-                Debug.Log($"[<color=#9585f1>Lavender</color>][Detailed] {message}");
+                if (BepinexPlugin.Settings.UseBepinexLog.Value)
+                {
+                    BepinexPlugin.Log.LogInfo($"[<color=#9585f1>Lavender</color>][Detailed] {message}");
+                }
+                else
+                {
+                    Debug.Log($"[<color=#9585f1>Lavender</color>][Detailed] {message}");
+                }
             }
         }
 
         public static void Error(string message)
         {
-            Debug.LogError($"[<color=#9585f1>Lavender</color>] {message}");
+            if (BepinexPlugin.Settings.UseBepinexLog.Value)
+            {
+                BepinexPlugin.Log.LogError($"[<color=#9585f1>Lavender</color>] {message}");
+            }
+            else
+            {
+                Debug.LogError($"[<color=#9585f1>Lavender</color>] {message}");
+            }
         }
     }
 }

--- a/Lavender/LavenderSettings.cs
+++ b/Lavender/LavenderSettings.cs
@@ -7,6 +7,7 @@ namespace Lavender
     public class LavenderSettings(ConfigFile config)
     {
         public ConfigEntry<bool> DetailedLog = config.Bind<bool>("Log", "DetailedLog", false, "Enable Detailed Log Output");
+        public ConfigEntry<bool> UseBepinexLog = config.Bind<bool>("Log", "UseBeginexLog", false, "Send logging through the BepinEx Plugin logger");
         public ConfigEntry<bool> SceneLoadingDoneNotification = config.Bind<bool>("Log", "SceneLoadingDoneNotification", true, "Enable 'Scene Loading Done' Notification");
 
         #region UNSTABLE PATCH SETTINGS


### PR DESCRIPTION
## About the PR
Fixed the Harmony patch definition of the FurniturePatch to BuildingSystem.AddFurniture.  It is ambiguous due to there being 2 functions both named AddFurniture (I assume this happened when Loiste added the furniture dev console commands).

Also wrapped the Harmony patching in a try/catch to yield better error reporting, and added a setting option to route Lavender's logging through BepInEx.

## How to test
1. Load into the game with both Lavender and Lavender Test plugins enabled
2. Open the dev console and enter: `add_item 102`
3. Observe that the item is correctly spawned

## Breaking changes
None