### PR TITLE
Update in-code documentation for DialogueLib and small tweaks

### DIFF
--- a/Lavender/DialogueLib/ConversationPatchesManager.cs
+++ b/Lavender/DialogueLib/ConversationPatchesManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Lavender.DialogueLib
 {
@@ -37,6 +38,10 @@ namespace Lavender.DialogueLib
             SaveController.LoadingDone -= OnLoadingDone;
         }
 
+        /// <summary>
+        /// You probably want Lavender.AddConversationPatcher().
+        /// </summary>
+        /// <param name="patcher"></param>
         public void AddConversationPatcher(ConversationPatcher patcher)
         {
             if (!Conversations.Contains(patcher))
@@ -64,6 +69,11 @@ namespace Lavender.DialogueLib
             }
         }
 
+        /// <summary>
+        /// You probably want Lavender.GetPatchersForConversation().
+        /// </summary>
+        /// <param name="conversationName"></param>
+        /// <returns></returns>
         public IEnumerable<ConversationPatcher> GetPatchersForConversation(string conversationName)
         {
             if (ConversationToPatcher.TryGetValue(conversationName, out var patchers))
@@ -73,6 +83,10 @@ namespace Lavender.DialogueLib
             return [];
         }
 
+        // Single access point to generate DialogueEntry IDs
+        // Allows us to dynamically avoid duplicate IDs at runtime
+        // Assumes that NewDialogueEntryStartingID is a high enough number that the vanilla dialogues don't reach it
+        //  If we start getting collisions with vanilla dialogues, we need to increase NewDialogueEntryStartingID
         public int GetNextDialogueEntryID()
         {
             // Intentional that this is a post-op increment
@@ -94,7 +108,14 @@ namespace Lavender.DialogueLib
             NextDialogueEntryID = NewDialogueEntryStartingID;
             foreach (var patcher in Conversations)
             {
-                patcher.TryPatchDialogue();
+                try
+                {
+                    patcher.TryPatchDialogue();
+                }
+                catch (Exception e)
+                {
+                    LavenderLog.Error($"Exception while patching conversation \"{patcher.ConversationName}\": " + e.ToString());
+                }
             }
         }
     }

--- a/Lavender/DialogueLib/LinkOrdering.cs
+++ b/Lavender/DialogueLib/LinkOrdering.cs
@@ -2,8 +2,10 @@
 
 namespace Lavender.DialogueLib
 {
-    // Helper class for more accurate control over insertion of links between dialogue entries
-    // The static initializer functions should provide configurations that handle most common usecases
+    /// <summary>
+    /// Helper class for more accurate control over insertion of links between dialogue entries.
+    /// The static initializer functions should provide configurations that handle most common usecases.
+    /// </summary>
     public class LinkOrdering
     {
         public DialogueEntry? AfterEntry = null;
@@ -16,48 +18,85 @@ namespace Lavender.DialogueLib
         public bool PreferLaterIfMatched = true;
         public bool PreferBeforeGoodbye = false;
 
-        // Prefers to place the link last in the available options, but before any "Goodbye"/"(Leave)" option
-        // May miss custom goodbye options, in which case you may need to use BeforeDialogue
+        /// <summary>
+        /// Create a LinkOrdering instance that prefers to place the link last in the available options, but before any "Goodbye"/"(Leave)" option
+        /// May miss custom goodbye options, in which case you may need to use BeforeDialogue
+        /// </summary>
+        /// <returns>A LinkOrdering instance ready for use with ConversationPatcher.Link()</returns>
         public static LinkOrdering DefaultOrdering()
         {
             return new LinkOrdering() { PreferBeforeGoodbye = true, PreferLaterIfMatched = true, PreferLater = true };
         }
 
-        // Try to put the link first in the list.  Note: Multiple links using this will compete for placement (there can only be 1 first place).
+        /// <summary>
+        /// Create a LinkOrdering instance that prefers to place the link first in the list.
+        /// Note: While it will place it first, it places it first at the moment that the link is created.  Overuse of this preset will cause links to get shuffled around.  
+        /// There can be only 1 first.
+        /// </summary>
+        /// <returns>A LinkOrdering instance ready for use with ConversationPatcher.Link()</returns>
         public static LinkOrdering First()
         {
             return new LinkOrdering() { PreferLater = false };
         }
 
-        // Guarantees the link will be placed before the specified response
-        // Will attempt to place the link directly before the response, if possible
+        /// <summary>
+        /// Create a LinkOrdering instance that guarantees the link will be placed before the specified response
+        /// Will attempt to place the link directly before the response, if possible
+        /// </summary>
+        /// <param name="entry">The entry to be in front of in the response list</param>
+        /// <returns>A LinkOrdering instance ready for use with ConversationPatcher.Link()</returns>
         public static LinkOrdering BeforeDialogue(DialogueEntry entry)
         {
             return new LinkOrdering() { BeforeEntry = entry, PreferLater = false, PreferLaterIfMatched = true };
         }
 
-        // Guarantees the link will be placed after the specified response
-        // Will attempt to place the link directly after the response, if possible
+        /// <summary>
+        /// Create a LinkOrdering instance that guarantees the link will be placed after the specified response
+        ///  Will attempt to place the link directly after the response, if possible
+        /// </summary>
+        /// <param name="entry">The entry to put the response after</param>
+        /// <returns>A LinkOrdering instance ready for use with ConversationPatcher.Link()</returns>
         public static LinkOrdering AfterDialogue(DialogueEntry entry)
         {
             return new LinkOrdering() { AfterEntry = entry, PreferLater = true, PreferLaterIfMatched = false };
         }
 
-        // Guarantees the link will be placed before the provided link
-        // Will attempt to place the new link directly before the provided link, if possible
+        /// <summary>
+        /// Create a LinkOrdering instance that guarantees the link will be placed before the provided link
+        /// Will attempt to place the new link directly before the provided link, if possible
+        /// Effectively an alias for BeforeDialogue().
+        /// </summary>
+        /// <param name="link">The link to be in front of in the response list</param>
+        /// <returns>A LinkOrdering instance ready for use with ConversationPatcher.Link()</returns>
         public static LinkOrdering BeforeResponse(Link link)
         {
             return new LinkOrdering() { BeforeLink = link, PreferLater = false, PreferLaterIfMatched = true };
         }
 
-        // Guarantees the link will be placed after the specified link
-        // Will attempt to place the new link directly after the provided link, if possible
+        /// <summary>
+        /// Create a LinkOrdering instance that guarantees the link will be placed after the specified link
+        /// Will attempt to place the new link directly after the provided link, if possible
+        /// Effectively an alias for AfterDialogue().
+        /// </summary>
+        /// <param name="link">The link to put the response after</param>
+        /// <returns>A LinkOrdering instance ready for use with ConversationPatcher.Link()</returns>
         public static LinkOrdering AfterResponse(Link link)
         {
             return new LinkOrdering() { AfterLink = link, PreferLater = true, PreferLaterIfMatched = false };
         }
 
-        public void AttachToDialogueEntry(Conversation conversation, DialogueEntry source, DialogueEntry dest, Link newLink)
+        /// <summary>
+        /// Handles the linking logic.  Not for external use - called automatically by the library.
+        /// Function is exposed should you want to implement your own custom linking logic:
+        /// 1) Subclass LinkOrdering
+        /// 2) Override AttachToDialogueEntry to implement your logic
+        /// 3) Create and pass an instance of your class to ConversationPatcher.Link()
+        /// </summary>
+        /// <param name="conversation">The interaction the linking happens within</param>
+        /// <param name="source">The DialogueEntry that is visible on the screen</param>
+        /// <param name="dest">The DialogueEntry that you are taken to when the response is selected (or automatically if NPC -> NPC or using a Sequence)</param>
+        /// <param name="newLink">The Link object that needs to be inserted into the source.outgoingLinks List.</param>
+        public virtual void AttachToDialogueEntry(Conversation conversation, DialogueEntry source, DialogueEntry dest, Link newLink)
         {
             int minIndex = 0;
             int maxIndex = source.outgoingLinks.Count;

--- a/Lavender/Lavender.cs
+++ b/Lavender/Lavender.cs
@@ -374,11 +374,27 @@ namespace Lavender
 
         #region DialogueLib
 
+        /// <summary>
+        /// Register a conversation patcher.
+        /// Should only be called once per conversation patch (probably during your mod startup).
+        /// Safe to be called at any time.
+        /// Each registered patch should be a unique object instance, even if you have 1 patcher that handles multiple conversations in the same class.
+        /// You can keep a reference to the patcher object after registration, but it is not required.
+        /// </summary>
+        /// <param name="patcher">Instantiated ConversationPatcher object that will be used to patch its conversation</param>
         public static void AddConversationPatcher(ConversationPatcher patcher)
         {
             ConversationPatchesManager.Instance.AddConversationPatcher(patcher);
         }
 
+        /// <summary>
+        /// Fetch all patcher objects that patch conversationName.
+        /// WARNING: Results may include patcher objects from other mods.
+        /// If you need to keep track of your patcher, it is strongly recommended that you do this with a List or variables in your mod instead of using this function.
+        /// This function is provided to be able to check for the presence of other patchers potentially affecting the same conversation - ie conflict detection.
+        /// </summary>
+        /// <param name="conversationName">The name of the conversation being patched.  For example: "Tenement/Outside/Tatyana Gopnikova"</param>
+        /// <returns>0 or more unique ConversationPatcher objects</returns>
         public IEnumerable<ConversationPatcher> GetPatchersForConversation(string conversationName)
         {
             return ConversationPatchesManager.Instance.GetPatchersForConversation(conversationName);


### PR DESCRIPTION
## About the PR
Main thing: Update the code level documentation for the DialogueLib and clarify some comments.

Also added some minor tweaks to the codebase:

- Wrap TryPatchDialogue in a try/catch block so 1 patcher crashing doesn't crash any others. 
- Made LinkOrdering.AttachToDialogueEntry virtual so it's possible to implement custom LinkOrdering implementations. 
- Made ConversationUtils class static to prevent instancing.

## How to test
Nothing changed here should have impacted functionality.  If testing is needed: Standard lavender test - Talk to Tatyana immediately after entering Obenseur.